### PR TITLE
Add page aesthetics tab

### DIFF
--- a/server.R
+++ b/server.R
@@ -707,6 +707,7 @@ server <- function(input, output, session) {
   
   tikz_node_points <- reactive({
     req(rvn$nodes)
+    update_tikz_because_global_opts()
     node_frame(rvn$nodes) %>% node_frame_add_style()
   })
   
@@ -785,6 +786,28 @@ server <- function(input, output, session) {
     }
     g
   }
+  
+  # ---- Tweak - Global Options ----
+  update_tikz_because_global_opts <- reactiveVal(FALSE)
+  
+  observe({
+    I("update tex_opts")
+    `%|%` <- function(x, y) {
+      x <- x %||% y
+      if (is.na(x)) y else x
+    }
+    tex_opts$set(list(
+      density = 1200,
+      margin = list(
+        left = input$tex_opts_margin_left %|% 0,
+        top = input$tex_opts_margin_bottom %|% 0, # bug?
+        right = input$tex_opts_margin_right %|% 0,
+        bottom = input$tex_opts_margin_top %|% 0
+      ),
+      cleanup = c("aux", "log")
+    ))
+    update_tikz_because_global_opts(!isolate(update_tikz_because_global_opts()))
+  })
 
   # ---- Tweak - dagitty DAG ----
   dag_dagitty <- reactive({

--- a/ui.R
+++ b/ui.R
@@ -23,6 +23,9 @@ two_column_flips_on_mobile <- function(left, right, override_width_classes = TRU
   fluidRow(right, left)
 }
 
+col_4 <- function(x) {
+  tags$div(class = "col-sm-6 col-md-3", style = "min-height: 80px", x)
+}
 
 # Components --------------------------------------------------------------
 
@@ -222,6 +225,25 @@ components$tweak <- tabBox(
     "Nodes",
     value = "edit_node_aesthetics",
     uiOutput("node_aes_ui")
+  ),
+  tabPanel(
+    "Page",
+    value = "edit_page_aesthetics",
+    tags$h3("Margins"),
+    fluidRow(
+      col_4(
+        numericInput("tex_opts_margin_top", "Top", value = 0L, min = 0L, max = 500L, step = 1L)
+      ),
+      col_4(
+        numericInput("tex_opts_margin_right", "Right", value = 0L, min = 0L, max = 500L, step = 1L)
+      ),
+      col_4(
+        numericInput("tex_opts_margin_bottom", "Bottom", value = 0L, min = 0L, max = 500L, step = 1L)
+      ),
+      col_4(
+        numericInput("tex_opts_margin_left", "Left", value = 0L, min = 0L, max = 500L, step = 1L)
+      )
+    )
   )
 )
 


### PR DESCRIPTION
Adds margin options as unitless number inputs.

It seems like `texPreview()` switches the top and bottom margins. I didn't see anything in the texPreview repo about this and don't have time to investigate, so I just switched them with a comment in the code. We may need to go back and revisit this at some point.