### PR TITLE
Fix removal of adjustment node from DAG

### DIFF
--- a/server.R
+++ b/server.R
@@ -472,12 +472,12 @@ server <- function(input, output, session) {
     }
   })
   
-  observeEvent(input$adjustNode, {
+  observe({
     nodes <- isolate(rvn$nodes)
-    if (is.null(input$adjustNode)) return()
-    s_adjust <- input$adjustNode
+    debug_input(input$adjustNode, "input$adjustNode")
+    s_adjust <- input$adjustNode %||% ""
     rvn$nodes <- if (length(s_adjust) == 1 && s_adjust == "") {
-      node_unset_attribute(nodes, names(node), "adjusted")
+      node_unset_attribute(nodes, names(nodes), "adjusted")
     } else {
       node_set_attribute(nodes, s_adjust, "adjusted")
     }

--- a/www/shinydag.css
+++ b/www/shinydag.css
@@ -169,6 +169,13 @@ body, h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6, .main-header .logo {
   padding-left: 5px;
 }
 
+/* make in-app debug pane resizable */
+#undo_rv-v_stack {
+  resize: vertical;
+  overflow-y: auto;
+  height: 160px;
+}
+
 @media (min-width: 992px) and (max-width: 1825px) {
   .btn-text {
     display: none;


### PR DESCRIPTION
Fun fact: `selectize("foo", ..., multiple = TRUE)` doesn't work well with `observeEvent(input$foo, {})`. When nothing is selected the `observeEvent` suppresses the reactivity from `input$foo`. Replacing with `observe()` resolves the issue.