### PR TITLE
Fill in missing values before applying node_frame_add_style()

### DIFF
--- a/R/node.R
+++ b/R/node.R
@@ -187,6 +187,7 @@ node_tikz_style <- function(hash, adjusted, color_draw, color_fill, color_text, 
 
 node_frame_add_style <- function(nodes) {
   if (!"name_latex" %in% names(nodes)) nodes$name_latex <- ""
+  nodes <- node_frame_replace_default(nodes)
   nodes %>% 
     mutate(
       tikz_style = purrr::pmap_chr(nodes, node_tikz_style),
@@ -199,6 +200,21 @@ node_frame_add_style <- function(nodes) {
         TRUE ~ name_latex
       )
     )
+}
+
+node_frame_replace_default <- function(nodes) {
+  tidyr::replace_na(nodes, list(
+    child = FALSE,
+    exposure = FALSE,
+    outcome = FALSE,
+    adjusted = FALSE,
+    name_latex = "",
+    visible = FALSE,
+    in_dag = FALSE,
+    color_draw = "Black",
+    color_fill = "White",
+    color_text = "Black"
+  ))
 }
 
 escape_quotes <- function(x) {

--- a/server.R
+++ b/server.R
@@ -711,7 +711,7 @@ server <- function(input, output, session) {
     update_tikz_because_global_opts()
     node_df <- node_frame(rvn$nodes)
     req(nrow(node_df) > 0)
-    node_df %>% node_frame_add_style()
+    node_frame_add_style(node_df)
   })
   
   tikz_code_from_app <- reactive({

--- a/server.R
+++ b/server.R
@@ -706,6 +706,7 @@ server <- function(input, output, session) {
   }
   
   tikz_node_points <- reactive({
+    req(input$shinydag_page %in% c("tweak", "latex"))
     req(length(rvn$nodes))
     update_tikz_because_global_opts()
     node_df <- node_frame(rvn$nodes)


### PR DESCRIPTION
When new nodes are added, they initially have `adjusted = NA` (and other variables) but `node_frame_add_style()` made a hard assumption that `adjusted` and others would be `TRUE` or `FALSE`. This commit fills in missing values with the default base values (as the missng cells are temporary and will be filled in once the inputs are created in the Tweaks page).